### PR TITLE
Add permission check for auth interceptor

### DIFF
--- a/services/user/dbinit-up.sql
+++ b/services/user/dbinit-up.sql
@@ -4,7 +4,8 @@ CREATE TABLE user_table(
     full_name text,
     email text,
     user_disabled boolean,
-    double_hashed_password text
+    double_hashed_password text,
+    user_role text
 );
 
 CREATE TABLE session_table(

--- a/services/user/main.py
+++ b/services/user/main.py
@@ -41,6 +41,13 @@ interceptors = [
             "/user.UserService/RefreshToken",
         ],
         audience="log-svcs",
+        permissions={
+            "/user.UserService/Logout": ["user", "admin"],
+            "/user.UserService/GetUserInfo": ["user", "admin"],
+            "/user.UserService/UpdateUserInfo": ["user", "admin"],
+            "/user.UserService/Unregister": ["user", "admin"],
+            "/user.UserService/ListUserInfo": ["admin"],
+        },
     )
 ]
 

--- a/services/user/service.py
+++ b/services/user/service.py
@@ -68,6 +68,7 @@ class UserService(object):
             "exp": access_expiration,
             "aud": self._audience,
             "sid": session_id,
+            "role": "user",  # TODO: populate this with DB values when "admin" role is implemented
         }
         access_token = jwt.encode(
             access_token_payload, self._jwk, algorithm=self._algorithm

--- a/services/user/user.proto
+++ b/services/user/user.proto
@@ -47,7 +47,7 @@ message GetJwkResponse{
 
 // TODO: documentation
 message LoginRequest {
-  string username = 1;
+  string email = 1;
   string hashed_password = 2;
 }
 


### PR DESCRIPTION
To allow a more fine-grained control based on token roles, add an endpoint-based permission schema on the interceptor.